### PR TITLE
fix: update message definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+.devcontainer
+.npmignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 .vscode
-.devcontainer
-.npmignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface ChatCompletionOptions {
    * https://platform.openai.com/docs/api-reference/chat/create#chat/create-messages
    */
   messages: {
-    name?: string; 
+    name?: string;
     role: "system" | "assistant" | "user";
     content: string;
   }[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,8 @@ export interface ChatCompletionOptions {
    * https://platform.openai.com/docs/api-reference/chat/create#chat/create-messages
    */
   messages: {
-    role: string;
+    name?: string; 
+    role: "system" | "assistant" | "user";
     content: string;
   }[];
 
@@ -613,7 +614,8 @@ export interface ChatCompletion {
   choices: {
     index: number;
     message: {
-      role: string;
+      name?: string;
+      role: "system" | "assistant" | "user";
       content: string;
     };
     finish_reason: string;


### PR DESCRIPTION
The message type can only have 3 possible roles: "system" | "assistant" | "user".
Messages can contain an optional name field. This is helpful in some applications, here's an example from OpenAI: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb.