### PR TITLE
feat: allow changing the API base URL

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -29,17 +29,17 @@ import type {
   Translation,
   TranslationOptions,
 } from "./types.ts";
-import { basename, posix } from "https://deno.land/std@0.185.0/path/mod.ts";
+import { basename } from "https://deno.land/std@0.185.0/path/mod.ts";
 
 const defaultBaseUrl = "https://api.openai.com/v1";
 
 export class OpenAI {
   #privateKey: string;
-  #baseUrl: URL;
+  #baseUrl: string;
 
-  constructor(privateKey: string, baseUrl?: string) {
+  constructor(privateKey: string, options?: { baseUrl?: string }) {
     this.#privateKey = privateKey;
-    this.#baseUrl = new URL(baseUrl ?? defaultBaseUrl);
+    this.#baseUrl = options?.baseUrl ?? defaultBaseUrl;
   }
 
   async #request(
@@ -49,10 +49,7 @@ export class OpenAI {
     options?: { method?: string; noContentType?: boolean },
   ) {
     const response = await fetch(
-      new URL(
-        posix.join(this.#baseUrl.pathname, url),
-        this.#baseUrl.origin,
-      ).href,
+      `${this.#baseUrl}${url}`,
       {
         body: options?.noContentType
           ? body
@@ -371,10 +368,7 @@ export class OpenAI {
    */
   async retrieveFileContent(fileId: string) {
     const response = await fetch(
-      new URL(
-        posix.join(this.#baseUrl.pathname, `/files/${fileId}/content`),
-        this.#baseUrl.origin,
-      ).href,
+      `${this.#baseUrl}/files/${fileId}/content`,
       {
         headers: {
           Authorization: `Bearer ${this.#privateKey}`,

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -30,7 +30,8 @@ import type {
   TranslationOptions,
 } from "./types.ts";
 import { basename } from "https://deno.land/std@0.185.0/path/mod.ts";
-import { urlJoin } from 'https://deno.land/x/url_join/mod.ts';
+import { urlJoin } from "https://deno.land/x/url_join@1.0.0/mod.ts";
+
 const defaultBaseUrl = "https://api.openai.com/v1";
 
 export class OpenAI {

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -30,14 +30,16 @@ import type {
   TranslationOptions,
 } from "./types.ts";
 import { basename } from "https://deno.land/std@0.185.0/path/mod.ts";
-
-const baseUrl = "https://api.openai.com/v1";
+import { urlJoin } from 'https://deno.land/x/url_join/mod.ts';
+const defaultBaseUrl = "https://api.openai.com/v1";
 
 export class OpenAI {
   #privateKey: string;
+  #baseUrl: string;
 
-  constructor(privateKey: string) {
+  constructor(privateKey: string, baseUrl?: string) {
     this.#privateKey = privateKey;
+    this.#baseUrl = baseUrl ?? defaultBaseUrl;
   }
 
   async #request(
@@ -46,7 +48,7 @@ export class OpenAI {
     body: any,
     options?: { method?: string; noContentType?: boolean },
   ) {
-    const response = await fetch(`${baseUrl}${url}`, {
+    const response = await fetch(urlJoin(this.#baseUrl, url), {
       body: options?.noContentType
         ? body
         : (body ? JSON.stringify(body) : undefined),
@@ -362,7 +364,7 @@ export class OpenAI {
    * https://platform.openai.com/docs/api-reference/files/retrieve-content
    */
   async retrieveFileContent(fileId: string) {
-    const response = await fetch(`${baseUrl}/files/${fileId}/content`, {
+    const response = await fetch(urlJoin(this.#baseUrl, 'files', fileId, 'content'), {
       headers: {
         Authorization: `Bearer ${this.#privateKey}`,
         "Content-Type": "application/json",


### PR DESCRIPTION
This allows you to specify a different base URL for the API. This can be helpful when using Microsoft Azure OpenAI Services for example. 