### PR TITLE
Fix createImageVariantion and createImageEdit

### DIFF
--- a/examples/imageEditWithFiles.ts
+++ b/examples/imageEditWithFiles.ts
@@ -1,0 +1,15 @@
+import { OpenAI } from "../mod.ts";
+
+const openAI = new OpenAI(Deno.env.get("YOUR_API_KEY")!);
+
+const imageBuffer = await Deno.open("@otter.png", { read: true });
+const maskBuffer = await Deno.open("@mask.png", { read: true });
+const imageEdit = await openAI.createImageEdit({
+  image: imageBuffer,
+  mask: maskBuffer,
+  prompt: "A cute baby sea otter wearing a beret",
+  n: 2,
+  size: "1024x1024",
+});
+
+console.log(imageEdit);

--- a/examples/imageVariationWithFiles.ts
+++ b/examples/imageVariationWithFiles.ts
@@ -1,0 +1,12 @@
+import { OpenAI } from "../mod.ts";
+
+const openAI = new OpenAI(Deno.env.get("YOUR_API_KEY")!);
+
+const imageBuffer = await Deno.open("@otter.png", { read: true });
+const imageVariation = await openAI.createImageVariation({
+  image: imageBuffer,
+  n: 2,
+  size: "1024x1024",
+});
+
+console.log(imageVariation);

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -267,14 +267,36 @@ export class OpenAI {
    * https://platform.openai.com/docs/api-reference/images/create-edit
    */
   async createImageEdit(options: ImageEditOptions): Promise<Image> {
-    return await this.#request(`/images/edits`, {
-      image: options.image,
-      mask: options.mask,
-      prompt: options.prompt,
-      n: options.n,
-      size: options.size,
-      response_format: options.responseFormat,
-      user: options.user,
+    const formData = new FormData();
+
+    // Model specified
+    formData.append("image", options.image);
+
+    // File data
+    if (typeof options.image === "string") {
+      const fileData = await Deno.readFile(options.image);
+
+      formData.append(
+        "image",
+        new File([fileData], basename(options.image)),
+      );
+    } else {
+      // Deno types are wrong
+      formData.append("image", options.image as unknown as Blob);
+    }
+
+    if (options.n) { formData.append("n", options.n); }
+    if (options.mask) { formData.append("mask", options.mask); }
+    if (options.prompt) { formData.append("prompt", options.prompt); }
+    if (options.size) { formData.append("size", options.size); }
+    if (options.user) { formData.append("user", options.user); }
+    if (options.responseFormat) {
+      formData.append("responseFormat", options.responseFormat);
+    }
+
+    return await this.#request(`/images/edits`, formData, {
+      noContentType: true,
+      method: "POST",
     });
   }
 
@@ -284,12 +306,34 @@ export class OpenAI {
    * https://platform.openai.com/docs/api-reference/images/create-variation
    */
   async createImageVariation(options: ImageVariationOptions): Promise<Image> {
-    return await this.#request(`/images/variations`, {
-      image: options.image,
-      n: options.n,
-      size: options.size,
-      response_format: options.responseFormat,
-      user: options.user,
+    const formData = new FormData();
+
+    // Model specified
+    formData.append("image", options.image);
+
+    // File data
+    if (typeof options.image === "string") {
+      const fileData = await Deno.readFile(options.image);
+
+      formData.append(
+        "image",
+        new File([fileData], basename(options.image)),
+      );
+    } else {
+      // Deno types are wrong
+      formData.append("image", options.image as unknown as Blob);
+    }
+
+    if (options.n) { formData.append("n", options.n); }
+    if (options.size) { formData.append("size", options.size); }
+    if (options.user) { formData.append("user", options.user); }
+    if (options.responseFormat) {
+      formData.append("responseFormat", options.responseFormat);
+    }
+
+    return await this.#request(`/images/variations`, formData, {
+      noContentType: true,
+      method: "POST",
     });
   }
 

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -291,7 +291,7 @@ export class OpenAI {
     if (options.size) { formData.append("size", options.size); }
     if (options.user) { formData.append("user", options.user); }
     if (options.responseFormat) {
-      formData.append("responseFormat", options.responseFormat);
+      formData.append("response_format", options.responseFormat);
     }
 
     return await this.#request(`/images/edits`, formData, {
@@ -328,7 +328,7 @@ export class OpenAI {
     if (options.size) { formData.append("size", options.size); }
     if (options.user) { formData.append("user", options.user); }
     if (options.responseFormat) {
-      formData.append("responseFormat", options.responseFormat);
+      formData.append("response_format", options.responseFormat);
     }
 
     return await this.#request(`/images/variations`, formData, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -372,7 +372,7 @@ export interface ImageEditOptions {
    * If mask is not provided, image must have transparency, which will be used as the mask.
    * https://platform.openai.com/docs/api-reference/images/create-edit#images/create-edit-image
    */
-  image: string;
+  image: FileSpecifier;
 
   /**
    * An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
@@ -417,7 +417,7 @@ export interface ImageVariationOptions {
    * The image to edit. Must be a valid PNG file, less than 4MB, and square.
    * https://platform.openai.com/docs/api-reference/images/create-variation#images/create-variation-image
    */
-  image: string;
+  image: FileSpecifier;
 
   /**
    * The number of images to generate. Must be between 1 and 10.


### PR DESCRIPTION
The functions `createImageVariantion` and `createImageEdit` should request using content type `multipart/form-data` instead of `application/json`.