### PR TITLE
feat: add stream delta type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -719,7 +719,11 @@ export interface ChatCompletion {
 export interface ChatCompletionStreamDelta {
   name?: string;
   role?: "system" | "assistant" | "user";
-  content?: string;
+  content?: string | null;
+  function_call?: {
+    name?: string;
+    arguments: string;
+  }
 }
 
 export interface ChatCompletionStream {

--- a/src/types.ts
+++ b/src/types.ts
@@ -733,7 +733,7 @@ export interface ChatCompletionStream {
   choices: {
     index: number;
     delta: ChatCompletionStreamDelta;
-    finish_reason: string;
+    finish_reason: string | null;
   }[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -716,17 +716,19 @@ export interface ChatCompletion {
   };
 }
 
+export interface ChatCompletionStreamDelta {
+  name?: string;
+  role?: "system" | "assistant" | "user";
+  content?: string;
+}
+
 export interface ChatCompletionStream {
   id: string;
   object: "chat.completion.chunk";
   created: number;
   choices: {
     index: number;
-    delta: {
-      name?: string;
-      role?: "system" | "assistant" | "user";
-      content?: string;
-    };
+    delta: ChatCompletionStreamDelta;
     finish_reason: string;
   }[];
 }


### PR DESCRIPTION
Closes #29 

- Extracted the type of `ChatCompletionStream['choices']['delta']` to `ChatCompletionStreamDelta` and exported it for readability and ease of use outside this module in user code
- Added the missing `function_call` type