### PR TITLE
Feat: use deps.ts and update the std version to latest

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,0 +1,2 @@
+export { TextDelimiterStream } from "https://deno.land/std@0.189.0/streams/mod.ts";
+export { basename } from "https://deno.land/std@0.189.0/path/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,2 +1,2 @@
-export { TextDelimiterStream } from "https://deno.land/std@0.189.0/streams/mod.ts";
-export { basename } from "https://deno.land/std@0.189.0/path/mod.ts";
+export { TextDelimiterStream } from "https://deno.land/std@0.204.0/streams/mod.ts";
+export { basename } from "https://deno.land/std@0.204.0/path/mod.ts";

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,4 +1,4 @@
-import { basename } from "https://deno.land/std@0.189.0/path/mod.ts";
+import { basename } from "./deps.ts";
 import { decodeStream, throwError } from "./util.ts";
 import type {
   ChatCompletion,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { TextDelimiterStream } from "https://deno.land/std@0.189.0/streams/mod.ts";
+import { TextDelimiterStream } from "./deps.ts";
 
 export function throwError(
   data: { error?: { type: string; message: string; code: string } },


### PR DESCRIPTION
This overrides and closes https://github.com/load1n9/openai/pull/34

We use  [deps.ts](https://docs.deno.com/runtime/tutorials/manage_dependencies) convention instead of locking version in `deno.json`